### PR TITLE
Morph: implement project service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import { HealthController } from './controllers/health.controller';
+import { ProjectController } from './controllers/project.controller';
 import { IdentityProvider } from './middleware/identity.provider';
 import { PermissionServiceClient } from './clients/permission-service.client';
+import { ProjectService } from './services/project.service';
 
 export function createApp(permissionServiceConfig: { host: string; port: number }) {
   const app = express();
@@ -10,9 +12,14 @@ export function createApp(permissionServiceConfig: { host: string; port: number 
   const identityProvider = new IdentityProvider();
   const permissionServiceClient = new PermissionServiceClient(permissionServiceConfig);
 
+  const projectService = new ProjectService(permissionServiceClient);
+  const projectController = new ProjectController(identityProvider, projectService);
+
   const healthController = new HealthController();
 
   app.get('/health', (req, res) => healthController.getHealth(req, res));
+  app.post('/projects', (req, res) => projectController.createProject(req, res));
+  app.get('/projects', (req, res) => projectController.getProjects(req, res));
 
   return app;
 }

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from 'express';
+import { IdentityProvider } from '../middleware/identity.provider';
+import { ProjectService } from '../services/project.service';
+
+export class ProjectController {
+  private identityProvider: IdentityProvider;
+  private projectService: ProjectService;
+
+  constructor(identityProvider: IdentityProvider, projectService: ProjectService) {
+    this.identityProvider = identityProvider;
+    this.projectService = projectService;
+  }
+
+  async createProject(req: Request, res: Response): Promise<void> {
+    const userId = this.identityProvider.getUserId(req);
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const { name, description } = req.body;
+    if (!name) {
+      res.status(400).json({ error: 'Name is required' });
+      return;
+    }
+    try {
+      const project = await this.projectService.createProject(userId, { name, description });
+      res.status(201).json(project);
+    } catch (err: any) {
+      if (err.message === 'Forbidden') {
+        res.status(403).json({ error: 'Forbidden' });
+      } else {
+        res.status(500).json({ error: 'Internal Server Error' });
+      }
+    }
+  }
+
+  async getProjects(req: Request, res: Response): Promise<void> {
+    const userId = this.identityProvider.getUserId(req);
+    if (!userId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    try {
+      const projects = await this.projectService.getProjects(userId);
+      res.status(200).json(projects);
+    } catch (err: any) {
+      if (err.message === 'Forbidden') {
+        res.status(403).json({ error: 'Forbidden' });
+      } else {
+        res.status(500).json({ error: 'Internal Server Error' });
+      }
+    }
+  }
+}

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -1,0 +1,47 @@
+import { v4 as uuidv4 } from 'uuid';
+import { PermissionServiceClient, Domain, Action } from '../clients/permission-service.client';
+
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+  ownerId: string;
+}
+
+interface CreateProjectPayload {
+  name: string;
+  description?: string;
+}
+
+export class ProjectService {
+  private projects: Project[] = [];
+  private permissionServiceClient: PermissionServiceClient;
+
+  constructor(permissionServiceClient: PermissionServiceClient) {
+    this.permissionServiceClient = permissionServiceClient;
+  }
+
+  async createProject(userId: string, payload: CreateProjectPayload): Promise<Project> {
+    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.CREATE);
+    if (!allowed) {
+      throw new Error('Forbidden');
+    }
+    const project: Project = {
+      id: uuidv4(),
+      name: payload.name,
+      description: payload.description,
+      ownerId: userId,
+    };
+    this.projects.push(project);
+    return project;
+  }
+
+  async getProjects(userId: string): Promise<Project[]> {
+    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.LIST);
+    if (!allowed) {
+      throw new Error('Forbidden');
+    }
+    // For simplicity, users see only their own projects
+    return this.projects.filter((p) => p.ownerId === userId);
+  }
+}

--- a/tests/integration/projects.test.ts
+++ b/tests/integration/projects.test.ts
@@ -1,0 +1,159 @@
+import request from 'supertest';
+import express from 'express';
+import { createApp } from '../../src/app';
+import nock from 'nock';
+import { Domain, Action } from '../../src/clients/permission-service.client';
+
+const permissionServiceHost = 'localhost';
+const permissionServicePort = 3001;
+const permissionServiceBaseUrl = `http://${permissionServiceHost}:${permissionServicePort}`;
+
+describe('Project API Integration Tests', () => {
+  let app: express.Application;
+  const userId = 'test-user';
+
+  beforeAll(() => {
+    app = createApp({ host: permissionServiceHost, port: permissionServicePort });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('POST /projects', () => {
+    it('should create a project when user has CREATE permission', async () => {
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query((params) =>
+          params.subjectId === userId &&
+          params.domain === Domain.PROJECT &&
+          params.action === Action.CREATE
+        )
+        .reply(200, { allowed: true });
+
+      const res = await request(app)
+        .post('/projects')
+        .set('identity-user-id', userId)
+        .send({ name: 'My Project', description: 'Test project' });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.name).toBe('My Project');
+      expect(res.body.description).toBe('Test project');
+      expect(res.body.ownerId).toBe(userId);
+    });
+
+    it('should return 401 if no user id', async () => {
+      const res = await request(app)
+        .post('/projects')
+        .send({ name: 'My Project' });
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 400 if no name', async () => {
+      const res = await request(app)
+        .post('/projects')
+        .set('identity-user-id', userId)
+        .send({ description: 'No name' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 403 if CREATE is forbidden', async () => {
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query((params) =>
+          params.subjectId === userId &&
+          params.domain === Domain.PROJECT &&
+          params.action === Action.CREATE
+        )
+        .reply(200, { allowed: false });
+
+      const res = await request(app)
+        .post('/projects')
+        .set('identity-user-id', userId)
+        .send({ name: 'Should fail' });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('GET /projects', () => {
+    it('should return empty list when no projects exist', async () => {
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query((params) =>
+          params.subjectId === userId &&
+          params.domain === Domain.PROJECT &&
+          params.action === Action.LIST
+        )
+        .reply(200, { allowed: true });
+
+      const res = await request(app)
+        .get('/projects')
+        .set('identity-user-id', userId);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBe(0);
+    });
+
+    it('should list only user\'s projects', async () => {
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query((params) =>
+          params.subjectId === userId &&
+          params.domain === Domain.PROJECT &&
+          params.action === Action.CREATE
+        )
+        .reply(200, { allowed: true });
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query((params) =>
+          params.subjectId === userId &&
+          params.domain === Domain.PROJECT &&
+          params.action === Action.LIST
+        )
+        .reply(200, { allowed: true });
+
+      // Create a project for user
+      await request(app)
+        .post('/projects')
+        .set('identity-user-id', userId)
+        .send({ name: 'Proj1' });
+
+      const res = await request(app)
+        .get('/projects')
+        .set('identity-user-id', userId);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.length).toBe(1);
+      expect(res.body[0].name).toBe('Proj1');
+      expect(res.body[0].ownerId).toBe(userId);
+    });
+
+    it('should return 401 if no user id', async () => {
+      const res = await request(app)
+        .get('/projects');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 403 if LIST is forbidden', async () => {
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query((params) =>
+          params.subjectId === userId &&
+          params.domain === Domain.PROJECT &&
+          params.action === Action.LIST
+        )
+        .reply(200, { allowed: false });
+
+      const res = await request(app)
+        .get('/projects')
+        .set('identity-user-id', userId);
+
+      expect(res.status).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
This PR contains the following modifications:

- AI (openai/gpt-4.1):
```
implement project controller and project service.
It should contain two features:
- user can create project with name and description
- user can get projects
Store data in memory in the project service.

user id is passes as a header and should be retrieved by identity provider in the controller and passed into the service. Then the service needs to use that user id to check permission service whether user has access (tests should assume the user has access). Permissions are CREATE and LIST in Project domain

Make integration tests for those two features. It should mock permission service using nock, so the test is a black box integration test.


```
 (Single file: No)

Generated by Morph.