### PR TITLE
Morph: Permission migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,18 +34,24 @@ export class PermissionServiceClient {
     this.baseUrl = `http://${config.host}:${config.port}`;
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`Checking permission for subjectId: ${subjectId}, domain: ${domain}, action: ${action}`);
+  async hasPermission(subjectId: string, domain: Domain, action: Action, tenantId?: string): Promise<boolean> {
+    console.log(`Checking permission for subjectId: ${subjectId}, domain: ${domain}, action: ${action}, tenantId: ${tenantId}`);
     try {
+      const params: any = {
+        subjectId,
+        domain,
+        action
+      };
+      
+      if (tenantId) {
+        params.tenantId = tenantId;
+      }
+
+      const endpoint = tenantId ? '/permissions/v2/check' : '/permissions/check';
+      
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
-        {
-          params: {
-            subjectId,
-            domain,
-            action
-          }
-        }
+        `${this.baseUrl}${endpoint}`,
+        { params }
       );
       console.log(`Permission response: ${response.data.allowed}`);
       return response.data.allowed;

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -7,4 +7,11 @@ export class IdentityProvider {
     console.log(`User ID found: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    console.log('Fetching tenant ID from request headers...');
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`Tenant ID found: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -21,9 +21,9 @@ export class ProjectService {
     this.permissionServiceClient = permissionServiceClient;
   }
 
-  async createProject(userId: string, payload: CreateProjectPayload): Promise<Project> {
+  async createProject(userId: string, payload: CreateProjectPayload, tenantId?: string): Promise<Project> {
     console.log(`Creating project for user: ${userId}`);
-    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.CREATE);
+    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.CREATE, tenantId);
     if (!allowed) {
       console.error('Forbidden: User not allowed to create project');
       throw new Error('Forbidden');
@@ -39,9 +39,9 @@ export class ProjectService {
     return project;
   }
 
-  async getProjects(userId: string): Promise<Project[]> {
+  async getProjects(userId: string, tenantId?: string): Promise<Project[]> {
     console.log(`Fetching projects for user: ${userId}`);
-    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.LIST);
+    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.LIST, tenantId);
     if (!allowed) {
       console.error('Forbidden: User not allowed to list projects');
       throw new Error('Forbidden');


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Single file: No)

Generated by Morph.