### PR TITLE
Morph: migrate to permission service

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,14 +34,15 @@ export class PermissionServiceClient {
     this.baseUrl = `http://${config.host}:${config.port}`;
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`Checking permission for subjectId: ${subjectId}, domain: ${domain}, action: ${action}`);
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
+    console.log(`Checking permission for subjectId: ${subjectId}, tenantId: ${tenantId}, domain: ${domain}, action: ${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -14,7 +14,8 @@ export class ProjectController {
   async createProject(req: Request, res: Response): Promise<void> {
     console.log('Creating a new project...');
     const userId = this.identityProvider.getUserId(req);
-    if (!userId) {
+    const tenantId = this.identityProvider.getTenantId(req);
+    if (!userId || !tenantId) {
       console.error('Unauthorized request');
       res.status(401).json({ error: 'Unauthorized' });
       return;
@@ -26,7 +27,7 @@ export class ProjectController {
       return;
     }
     try {
-      const project = await this.projectService.createProject(userId, { name, description });
+      const project = await this.projectService.createProject(userId, tenantId, { name, description });
       console.log('Project created:', project);
       res.status(201).json(project);
     } catch (err: any) {
@@ -43,13 +44,14 @@ export class ProjectController {
   async getProjects(req: Request, res: Response): Promise<void> {
     console.log('Retrieving projects...');
     const userId = this.identityProvider.getUserId(req);
-    if (!userId) {
+    const tenantId = this.identityProvider.getTenantId(req);
+    if (!userId || !tenantId) {
       console.error('Unauthorized request');
       res.status(401).json({ error: 'Unauthorized' });
       return;
     }
     try {
-      const projects = await this.projectService.getProjects(userId);
+      const projects = await this.projectService.getProjects(userId, tenantId);
       console.log('Projects retrieved:', projects);
       res.status(200).json(projects);
     } catch (err: any) {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -7,4 +7,11 @@ export class IdentityProvider {
     console.log(`User ID found: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    console.log('Fetching tenant ID from request headers...');
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`Tenant ID found: ${tenantId}`);
+    return tenantId || null;
+  }
 }


### PR DESCRIPTION
This PR contains the following modifications:

- AI (gemini/gemini-2.5-flash-lite):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /permissions/v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

Do not keep the old logic in permission service client.

```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)