### PR TITLE
Morph: Permission service migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -34,14 +34,15 @@ export class PermissionServiceClient {
     this.baseUrl = `http://${config.host}:${config.port}`;
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`Checking permission for subjectId: ${subjectId}, domain: ${domain}, action: ${action}`);
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
+    console.log(`Checking permission for subjectId: ${subjectId}, tenantId: ${tenantId}, domain: ${domain}, action: ${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/v2/permissions/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -26,7 +26,13 @@ export class ProjectController {
       return;
     }
     try {
-      const project = await this.projectService.createProject(userId, { name, description });
+      const tenantId = this.identityProvider.getTenantId(req);
+      if (!tenantId) {
+        console.error('Tenant ID is required');
+        res.status(400).json({ error: 'Tenant ID is required' });
+        return;
+      }
+      const project = await this.projectService.createProject(userId, tenantId, { name, description });
       console.log('Project created:', project);
       res.status(201).json(project);
     } catch (err: any) {
@@ -49,7 +55,13 @@ export class ProjectController {
       return;
     }
     try {
-      const projects = await this.projectService.getProjects(userId);
+      const tenantId = this.identityProvider.getTenantId(req);
+      if (!tenantId) {
+        console.error('Tenant ID is required');
+        res.status(400).json({ error: 'Tenant ID is required' });
+        return;
+      }
+      const projects = await this.projectService.getProjects(userId, tenantId);
       console.log('Projects retrieved:', projects);
       res.status(200).json(projects);
     } catch (err: any) {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -7,4 +7,11 @@ export class IdentityProvider {
     console.log(`User ID found: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    console.log('Fetching tenant ID from request headers...');
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`Tenant ID found: ${tenantId}`);
+    return tenantId || null;
+  }
 }

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -21,9 +21,9 @@ export class ProjectService {
     this.permissionServiceClient = permissionServiceClient;
   }
 
-  async createProject(userId: string, payload: CreateProjectPayload): Promise<Project> {
-    console.log(`Creating project for user: ${userId}`);
-    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.CREATE);
+  async createProject(userId: string, tenantId: string, payload: CreateProjectPayload): Promise<Project> {
+    console.log(`Creating project for user: ${userId}, tenant: ${tenantId}`);
+    const allowed = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.PROJECT, Action.CREATE);
     if (!allowed) {
       console.error('Forbidden: User not allowed to create project');
       throw new Error('Forbidden');
@@ -39,9 +39,9 @@ export class ProjectService {
     return project;
   }
 
-  async getProjects(userId: string): Promise<Project[]> {
-    console.log(`Fetching projects for user: ${userId}`);
-    const allowed = await this.permissionServiceClient.hasPermission(userId, Domain.PROJECT, Action.LIST);
+  async getProjects(userId: string, tenantId: string): Promise<Project[]> {
+    console.log(`Fetching projects for user: ${userId}, tenant: ${tenantId}`);
+    const allowed = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.PROJECT, Action.LIST);
     if (!allowed) {
       console.error('Forbidden: User not allowed to list projects');
       throw new Error('Forbidden');


### PR DESCRIPTION
This PR contains the following modifications:

- AI (deepseek/deepseek-chat):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)